### PR TITLE
Updated blog_details hook to site_details to maintain wordpress 4.7+ …

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a workaround to allow sorting the sites based on categories.
 There's a filter being applied (except in the sites screen) that tells WordPress that the site is **not mature**:
 ```
 if( 'sites.php' != $pagenow )
-    add_filter( 'blog_details', array( $this, 'hack_mature_queries' ) );	
+    add_filter( 'site_details', array( $this, 'hack_mature_queries' ) );	
 public function hack_mature_queries( $details )
 {
     $details->mature = 0;

--- a/multisite-site-category.php
+++ b/multisite-site-category.php
@@ -176,7 +176,7 @@ class B5F_Multisite_Categories
         
         # WP, ALL MATURES ARE OK
         if( 'sites.php' != $pagenow )
-            add_filter( 'blog_details', array( $this, 'hack_mature_queries' ) );	
+            add_filter( 'site_details', array( $this, 'hack_mature_queries' ) );	
 
         # BAIL OUT
         if( !is_network_admin() )


### PR DESCRIPTION
Wordpress 4.7+ deprecated the hook blog_details and replaced with site_details.

https://developer.wordpress.org/reference/hooks/blog_details/